### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,10 @@
     <artifactId>CucumberBasics</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+	<maven.compiler.source>1.6</maven.compiler.source>
+	<maven.compiler.target>1.6</maven.compiler.target>
+    </properties>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.5.1:compile (default-compile) on project CucumberBasics: Compilation failure: Compilation failure: 
[ERROR] Source option 1.5 is no longer supported. Use 1.6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.