### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,16 @@
             <artifactId>cucumber-testng</artifactId>
             <version>6.9.1</version>
         </dependency>
+	    
+	<!-- https://mvnrepository.com/artifact/org.testng/testng -->
+<dependency>
+    <groupId>org.testng</groupId>
+    <artifactId>testng</artifactId>
+    <version>7.4.0</version>
+    <scope>test</scope>
+</dependency>
+
+	    
 
         <!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-testng -->
         <dependency>


### PR DESCRIPTION
Was getting this error while practicing lesson 7 of Build, Deploy, Test with Jenkins 2.0 ---- TestNG by default disables loading DTD from unsecured Urls. If you need to explicitly load the DTD from a http url, please do so by using the JVM argument [-Dtestng.dtd.http=true] ---

hence made this update based on google search and it fixed the error